### PR TITLE
Improving Cython Wrapper

### DIFF
--- a/ripser/pyRips.pxd
+++ b/ripser/pyRips.pxd
@@ -1,10 +1,16 @@
 from libcpp.vector cimport vector
 
 cdef extern from "ripser.cpp":
-	vector[float] rips_dm(float* D, int N, int modulus, 
+	ctypedef struct ripserResults:
+		vector[vector[float]] births_and_deaths_by_dim
+		vector[vector[vector[int]]] cocycles_by_dim
+		int num_edges
+
+cdef extern from "ripser.cpp":
+	ripserResults rips_dm(float* D, int N, int modulus, 
 					     int dim_max, float threshold, int do_cocycles)
 	
 cdef extern from "ripser.cpp":
-	vector[float] rips_dm_sparse(int* I, int* J, float* V, int NEdges, 
+	ripserResults rips_dm_sparse(int* I, int* J, float* V, int NEdges, 
 							   int N, int modulus, int dim_max, 
 							   float threshold, int do_cocycles)


### PR DESCRIPTION
The code now returns a python struct with lists of persistence diagrams and cocycles by dimension, instead of everything mixed up and interleaved in one array.  This allows a better separation of types (no longer mixing ints and floats), and it also makes the unwrapping code on the Python side more elegant and easier to debug.