### PR TITLE
Collect windows binary artifacts in appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,3 +25,13 @@ install:
 
 test_script: 
   - pytest .
+
+after_test:
+  # If tests are successful, create binary packages for the project.
+  - python setup.py bdist_wheel"
+  - python setup.py bdist_wininst"
+  - ps: "ls dist"
+
+artifacts:
+  # Archive the generated packages in the ci.appveyor.com build report.
+  - path: dist\*


### PR DESCRIPTION
Appveyor will keep windows binaries around as artifacts so we can deploy them to pypi.

The deployment has intentionally not been automated.